### PR TITLE
cmsdk: Fix lint warning in string conversion

### DIFF
--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/PerformanceManagerService.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/PerformanceManagerService.java
@@ -43,6 +43,7 @@ import java.io.PrintWriter;
 import java.util.ArrayDeque;
 import java.util.Date;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Pattern;
@@ -132,7 +133,7 @@ public class PerformanceManagerService extends CMSystemService {
                 if (info.length == 2) {
                     mAppProfiles.put(Pattern.compile(info[0]), Integer.valueOf(info[1]));
                     if (DEBUG) {
-                        Slog.d(TAG, String.format("App profile #%d: %s => %s",
+                        Slog.d(TAG, String.format(Locale.US,"App profile #%d: %s => %s",
                                 i, info[0], info[1]));
                     }
                 }
@@ -273,7 +274,7 @@ public class PerformanceManagerService extends CMSystemService {
      */
     private boolean setPowerProfileLocked(int profile, boolean fromUser) {
         if (DEBUG) {
-            Slog.v(TAG, String.format("setPowerProfileL(%d, fromUser=%b)", profile, fromUser));
+            Slog.v(TAG, String.format(Locale.US,"setPowerProfileL(%d, fromUser=%b)", profile, fromUser));
         }
 
         if (!mSystemReady) {

--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/display/LiveDisplayService.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/display/LiveDisplayService.java
@@ -53,6 +53,7 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 
 import cyanogenmod.app.CMContextConstants;
 import cyanogenmod.app.CMStatusBarManager;
@@ -124,7 +125,7 @@ public class LiveDisplayService extends CMSystemService {
 
         @Override
         public String toString() {
-            return String.format(
+            return String.format(Locale.US,
                     "[mLowPowerMode=%b, mScreenOn=%b, mMode=%d, mTwilight=%s",
                     mLowPowerMode, mScreenOn, mMode,
                     (mTwilight == null ? "NULL" : mTwilight.toString()));


### PR DESCRIPTION
Implicitly using the default locale is a common source of bugs: Use String.format(Locale, ...) instead
http://developer.android.com/reference/java/util/Locale.html#default_locale

Change-Id: I18abb9aa545961bebcb40e3a57152617a22e284f