### PR TITLE
cmsdk: cmhw: Deprecate TAP_TO_WAKE feature

### DIFF
--- a/api/cm_current.txt
+++ b/api/cm_current.txt
@@ -512,7 +512,7 @@ package cyanogenmod.hardware {
     field public static final int FEATURE_PICTURE_ADJUSTMENT = 262144; // 0x40000
     field public static final int FEATURE_SERIAL_NUMBER = 128; // 0x80
     field public static final int FEATURE_SUNLIGHT_ENHANCEMENT = 256; // 0x100
-    field public static final int FEATURE_TAP_TO_WAKE = 512; // 0x200
+    field public static final deprecated int FEATURE_TAP_TO_WAKE = 512; // 0x200
     field public static final int FEATURE_THERMAL_MONITOR = 32768; // 0x8000
     field public static final int FEATURE_TOUCH_HOVERING = 2048; // 0x800
     field public static final int FEATURE_UNIQUE_DEVICE_ID = 65536; // 0x10000

--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/CMHardwareService.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/CMHardwareService.java
@@ -54,7 +54,6 @@ import org.cyanogenmod.hardware.PersistentStorage;
 import org.cyanogenmod.hardware.PictureAdjustment;
 import org.cyanogenmod.hardware.SerialNumber;
 import org.cyanogenmod.hardware.SunlightEnhancement;
-import org.cyanogenmod.hardware.TapToWake;
 import org.cyanogenmod.hardware.ThermalMonitor;
 import org.cyanogenmod.hardware.ThermalUpdateCallback;
 import org.cyanogenmod.hardware.TouchscreenHovering;
@@ -143,8 +142,6 @@ public class CMHardwareService extends CMSystemService implements ThermalUpdateC
                 mSupportedFeatures |= CMHardwareManager.FEATURE_SERIAL_NUMBER;
             if (SunlightEnhancement.isSupported())
                 mSupportedFeatures |= CMHardwareManager.FEATURE_SUNLIGHT_ENHANCEMENT;
-            if (TapToWake.isSupported())
-                mSupportedFeatures |= CMHardwareManager.FEATURE_TAP_TO_WAKE;
             if (VibratorHW.isSupported())
                 mSupportedFeatures |= CMHardwareManager.FEATURE_VIBRATOR;
             if (TouchscreenHovering.isSupported())
@@ -181,8 +178,6 @@ public class CMHardwareService extends CMSystemService implements ThermalUpdateC
                     return KeyDisabler.isActive();
                 case CMHardwareManager.FEATURE_SUNLIGHT_ENHANCEMENT:
                     return SunlightEnhancement.isEnabled();
-                case CMHardwareManager.FEATURE_TAP_TO_WAKE:
-                    return TapToWake.isEnabled();
                 case CMHardwareManager.FEATURE_TOUCH_HOVERING:
                     return TouchscreenHovering.isEnabled();
                 case CMHardwareManager.FEATURE_AUTO_CONTRAST:
@@ -207,8 +202,6 @@ public class CMHardwareService extends CMSystemService implements ThermalUpdateC
                     return KeyDisabler.setActive(enable);
                 case CMHardwareManager.FEATURE_SUNLIGHT_ENHANCEMENT:
                     return SunlightEnhancement.setEnabled(enable);
-                case CMHardwareManager.FEATURE_TAP_TO_WAKE:
-                    return TapToWake.setEnabled(enable);
                 case CMHardwareManager.FEATURE_TOUCH_HOVERING:
                     return TouchscreenHovering.setEnabled(enable);
                 case CMHardwareManager.FEATURE_AUTO_CONTRAST:

--- a/sdk/src/java/cyanogenmod/hardware/CMHardwareManager.java
+++ b/sdk/src/java/cyanogenmod/hardware/CMHardwareManager.java
@@ -111,7 +111,10 @@ public final class CMHardwareManager {
 
     /**
      * Double-tap the touch panel to wake up the device
+     *
+     * @deprecated This functionality is replaced by AOSP's implementation as of CM 13.0.
      */
+    @Deprecated
     @VisibleForTesting
     public static final int FEATURE_TAP_TO_WAKE = 0x200;
 
@@ -175,7 +178,6 @@ public final class CMHardwareManager {
         FEATURE_HIGH_TOUCH_SENSITIVITY,
         FEATURE_KEY_DISABLE,
         FEATURE_SUNLIGHT_ENHANCEMENT,
-        FEATURE_TAP_TO_WAKE,
         FEATURE_TOUCH_HOVERING,
         FEATURE_AUTO_CONTRAST,
         FEATURE_THERMAL_MONITOR

--- a/tests/src/org/cyanogenmod/tests/hardware/CMHardwareTest.java
+++ b/tests/src/org/cyanogenmod/tests/hardware/CMHardwareTest.java
@@ -44,7 +44,6 @@ public class CMHardwareTest extends TestActivity {
             CMHardwareManager.FEATURE_LONG_TERM_ORBITS,
             CMHardwareManager.FEATURE_SERIAL_NUMBER,
             CMHardwareManager.FEATURE_SUNLIGHT_ENHANCEMENT,
-            CMHardwareManager.FEATURE_TAP_TO_WAKE,
             CMHardwareManager.FEATURE_TOUCH_HOVERING,
             CMHardwareManager.FEATURE_AUTO_CONTRAST,
             CMHardwareManager.FEATURE_DISPLAY_MODES,
@@ -61,7 +60,6 @@ public class CMHardwareTest extends TestActivity {
             "FEATURE_LONG_TERM_ORBITS",
             "FEATURE_SERIAL_NUMBER",
             "FEATURE_SUNLIGHT_ENHANCEMENT",
-            "FEATURE_TAP_TO_WAKE",
             "FEATURE_TOUCH_HOVERING",
             "FEATURE_AUTO_CONTRAST",
             "FEATURE_DISPLAY_MODES",
@@ -74,7 +72,6 @@ public class CMHardwareTest extends TestActivity {
             CMHardwareManager.FEATURE_HIGH_TOUCH_SENSITIVITY,
             CMHardwareManager.FEATURE_KEY_DISABLE,
             CMHardwareManager.FEATURE_SUNLIGHT_ENHANCEMENT,
-            CMHardwareManager.FEATURE_TAP_TO_WAKE,
             CMHardwareManager.FEATURE_TOUCH_HOVERING,
             CMHardwareManager.FEATURE_AUTO_CONTRAST
     );


### PR DESCRIPTION
All devices should use the native implementation now.

Change-Id: Ic29472ba28569536a8556f61229a8a8fe783354a