### PR TITLE
Protect system profiles related broadcasts

### DIFF
--- a/cm/res/AndroidManifest.xml
+++ b/cm/res/AndroidManifest.xml
@@ -32,6 +32,9 @@
     <protected-broadcast android:name="cyanogenmod.intent.action.UPDATE_PREFERENCE" />
     <protected-broadcast android:name="cyanogenmod.intent.action.REFRESH_PREFERENCE" />
 
+    <protected-broadcast android:name="cyanogenmod.platform.intent.action.PROFILE_UPDATED" />
+    <protected-broadcast android:name="cyanogenmod.platform.intent.action.INTENT_ACTION_PROFILE_TRIGGER_STATE_CHANGED" />
+
     <!-- Must be required by an, to ensure that only the system can bind to it.
          @hide -->
     <permission android:name="cyanogenmod.permission.BIND_CUSTOM_TILE_LISTENER_SERVICE"


### PR DESCRIPTION
System components should only send protected broadcasts.

Change-Id: Ia3f38483270fe131db37559155a259989a837230