### PR TITLE
cmsdk: fix twilight state not updating in live display auto mode

### DIFF
--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/display/TwilightTracker.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/display/TwilightTracker.java
@@ -50,6 +50,8 @@ import libcore.util.Objects;
 public final class TwilightTracker {
     private static final String TAG = "TwilightTracker";
     private static final boolean DEBUG = false;
+    private static final String ACTION_UPDATE_TWILIGHT_STATE =
+            "cyanogenmod.platform.intent.action.UPDATE_TWILIGHT_STATE";
 
     private final Object mLock = new Object();
 
@@ -74,7 +76,7 @@ public final class TwilightTracker {
         IntentFilter filter = new IntentFilter(Intent.ACTION_AIRPLANE_MODE_CHANGED);
         filter.addAction(Intent.ACTION_TIME_CHANGED);
         filter.addAction(Intent.ACTION_TIMEZONE_CHANGED);
-        filter.addAction(TwilightTracker.class.getName());
+        filter.addAction(ACTION_UPDATE_TWILIGHT_STATE);
         mContext.registerReceiver(mUpdateLocationReceiver, filter);
     }
 
@@ -392,7 +394,7 @@ public final class TwilightTracker {
                 Slog.d(TAG, "Next update in " + (nextUpdate - now) + " ms");
             }
 
-            Intent updateIntent = new Intent(mContext, TwilightTracker.class);
+            Intent updateIntent = new Intent(ACTION_UPDATE_TWILIGHT_STATE);
             PendingIntent pendingIntent = PendingIntent.getBroadcast(
                     mContext, 0, updateIntent, 0);
             mAlarmManager.cancel(pendingIntent);

--- a/cm/res/AndroidManifest.xml
+++ b/cm/res/AndroidManifest.xml
@@ -35,6 +35,8 @@
     <protected-broadcast android:name="cyanogenmod.platform.intent.action.PROFILE_UPDATED" />
     <protected-broadcast android:name="cyanogenmod.platform.intent.action.INTENT_ACTION_PROFILE_TRIGGER_STATE_CHANGED" />
 
+    <protected-broadcast android:name="cyanogenmod.platform.intent.action.UPDATE_TWILIGHT_STATE" />
+
     <!-- Must be required by an, to ensure that only the system can bind to it.
          @hide -->
     <permission android:name="cyanogenmod.permission.BIND_CUSTOM_TILE_LISTENER_SERVICE"


### PR DESCRIPTION
The broadcast receiver filter was missing the action to trigger the
twilight state update for the next day. Therefore the time+date when
to go day and night mode were stuck on a previous day.

BUGBASH-226

Change-Id: I2c87b738b20d5c08dffe4c20e13a990167b5a22b